### PR TITLE
Reuse secondary peaks from subpixel peak-finding for SNR calculation

### DIFF
--- a/Cal_SNR.m
+++ b/Cal_SNR.m
@@ -1,4 +1,4 @@
-function SNR = Cal_SNR(G,metric)
+function SNR = Cal_SNR(G,metric,varargin)
 % [ PPR PRMSR PCE ENTROPY ] = Cal_SNR( G )
 % This function is used to calculate the basic SNR of the correlation plane
 % The only input you need is the correlation plane (SCC,RPC)
@@ -11,6 +11,8 @@ CoPlane1 = G;
 CoPlane = CoPlane1-min(CoPlane1(:)); %minimum subtraction to eliminate background noise effect
 NX = size(CoPlane,2);
 NY = size(CoPlane,1);
+
+if isempty(varargin)
 [Max(1),Ind(1)] = max(CoPlane(:)); %find the primary peak
 tem = imregionalmax(CoPlane);
 peakmat = CoPlane.*tem;
@@ -18,6 +20,9 @@ NPeak = 2; %number of peaks you want to include
 for i = 2:NPeak
     peakmat(peakmat==Max(i-1)) = 0;
     [Max(i),Ind(i)] = max(peakmat(:)); % find the second and third peak (although the third peak is not used)
+end
+else % Reuse pre-computed peaks
+    Max = varargin{1};
 end
 PEAKMAGNI = Max (1)^2;  %magnitude of the primary peak
 
@@ -80,4 +85,5 @@ SNR=ENTROPY;
 end
 
 end
-
+    
+    

--- a/PIVwindowed.m
+++ b/PIVwindowed.m
@@ -385,7 +385,7 @@ switch upper(tcorr)
                     G(5) = abs( sum(sum(region1( :, 2:end  ).*region2( :, 1:end-1)))+sum(region1(:,1  ).*region2(:,end)) );
                     G(2) = abs( sum(sum(region1(1:end-1, : ).*region2(2:end  , : )))+sum(region1(end,:).*region2(1,  :)) );
                     G(4) = abs( sum(sum(region1(2:end  , : ).*region2(1:end-1, : )))+sum(region1(1  ,:).*region2(end,:)) );
-                   
+                    
                     if max(G)~=G(3)
                         %dump the subset, and start over at first color index
                         %(incr. at end of while loop back to 1)
@@ -442,8 +442,8 @@ switch upper(tcorr)
                 
                     % Evaluate uncertainty options for SCC
                     if uncertainty.ppruncertainty==1
-                         %SNR calculation the other output arguments of Cal_SNR
-                         %are Maximum peak value,PRMSR,PCE,ENTROPY
+                            %SNR calculation the other output arguments of Cal_SNR
+                            %are Maximum peak value,PRMSR,PCE,ENTROPY
                         metric='PPR';
                         PPRval = Cal_SNR(G,metric);
                         % Save the SNR metrics
@@ -840,12 +840,16 @@ switch upper(tcorr)
                     Corrplanes(:,:,n) = G;
                 end
                 
-                 % Evaluate uncertainty options for RPC
+                    % Evaluate uncertainty options for RPC
                 if uncertainty.ppruncertainty==1
-                     %SNR calculation the other output arguments of Cal_SNR
-                     %are Maximum peak value,PRMSR,PCE,ENTROPY
+                        %SNR calculation the other output arguments of Cal_SNR
+                        %are Maximum peak value,PRMSR,PCE,ENTROPY
                     metric='PPR';
-                    PPRval = Cal_SNR(G,metric);
+                    if Peakswitch % Can reuse secondary peak calc'd in `subpixel`
+                        PPRval = Cal_SNR(G,metric,Ctemp);
+                    else
+                        PPRval = Cal_SNR(G,metric);
+                    end
                     % Save the SNR metrics
                     SNRmetric.PPR(n)=PPRval;
                     % Evaluate PPR Uncertainty
@@ -976,3 +980,4 @@ if ~exist('uncertainty2D','var')
 end
 
 end
+    


### PR DESCRIPTION
Profiling showed that a large fraction of robust phase correlation runtime was occupied by the `imregionalmax` builtin, which is used to find local maxima of correlation planes in both  `subpixel` and `Cal_SNR`, which are called in the inner loop. By reusing the peak magnitude results if available, roughly 35% of runtime can be avoided.